### PR TITLE
use sudo for pip install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM jujusolutions/charmbox:latest
 
 #RUN pip2 install cloud-weather-report
 RUN git clone https://github.com/juju-solutions/cloud-weather-report.git /home/ubuntu/cloud-weather-report
-RUN pip2 install -r /home/ubuntu/cloud-weather-report/requirements.txt
+RUN sudo -H pip2 install -r /home/ubuntu/cloud-weather-report/requirements.txt


### PR DESCRIPTION
now that jujubox (and therefore charmbox) run as the ubuntu user, we'll need to call pip with sudo.  use sudo -H to use ~ubuntu's home dir for pip bits.